### PR TITLE
Adds Secrets support to drone-marathon plugin.

### DIFF
--- a/content/e20co/drone-marathon/index.md
+++ b/content/e20co/drone-marathon/index.md
@@ -78,19 +78,24 @@ Will result in:
 
 # Secrets
 
-The Marathon plugin supports reading credentials from the Drone secret store. This is highly recommended instead of storing credentials in the pipeline configuration in plain text.
+The Marathon plugin supports reading credentials from the Drone secret store. This is highly recommended instead of storing credentials in the pipeline configuration in plain text.  This plugin will accept any secret that starts with `MARATHON_` injected into the `e20co/drone-marathon` environment, and make it available to your `marathonfile` as follows:
 
+in `marathon.json` (or custom `marathonfile`):
 ```diff
-pipeline:
-  marathon:
-    image: e20co/drone-marathon:0.5
-    server: http://marathon.mesos:8080
-    values:
--     DATABASE_PASSWORD: SomeSecretPassword
-+     DATABASE_PASSWORD: ${DATABASE_PASSWORD}
+{
+...
+  "env": {
+-   "DATABASE_PASSWORD": "SomeSecretPassword"
++   "DATABASE_PASSWORD": "<<MARATHON_DATABASE_PASSWORD>>"
+  }
+}
 ```
 
-The above example will replace the `DATABASE_PASSWORD` value set in the Drone secret store as appropriate.  Any secret defined for `--image=e20co/drone-marathon` will be made available for use in your `.drone.yml`.  Please see the Drone documentation to learn more about secrets.
+```
+$ drone secret add --image=e20co/drone-marathon <repo> MARATHON_DATABASE_PASSWORD SomeSecretPassword
+```
+
+The above example will replace `<<MARATHON_DATABASE_PASSWORD>>` with the value from your Drone Secret Store at runtime.  Please see the Drone documentation to learn more about secrets.
 
 # Parameter Reference
 

--- a/content/e20co/drone-marathon/index.md
+++ b/content/e20co/drone-marathon/index.md
@@ -78,7 +78,19 @@ Will result in:
 
 # Secrets
 
-Not Implemented.
+The Marathon plugin supports reading credentials from the Drone secret store. This is highly recommended instead of storing credentials in the pipeline configuration in plain text.
+
+```diff
+pipeline:
+  marathon:
+    image: e20co/drone-marathon:0.5
+    server: http://marathon.mesos:8080
+    values:
+-     DATABASE_PASSWORD: SomeSecretPassword
++     DATABASE_PASSWORD: ${DATABASE_PASSWORD}
+```
+
+The above example will replace the `DATABASE_PASSWORD` value set in the Drone secret store as appropriate.  Any secret defined for `--image=e20co/drone-marathon` will be made available for use in your `.drone.yml`.  Please see the Drone documentation to learn more about secrets.
 
 # Parameter Reference
 


### PR DESCRIPTION
This functionality has already been included in the `0.5` tag.  This updates the documentation so others can use this as well.  Enjoy!
