### PR TITLE
Add 'args' parameter to rsync plugin docs

### DIFF
--- a/content/drillster/drone-rsync/index.md
+++ b/content/drillster/drone-rsync/index.md
@@ -89,5 +89,8 @@ recursive
 delete
 : instruct plugin to delete the target folder before copying, can be `true` or `false`, defaults to `false`
 
+args
+: instruct plugin to use these additional rsync CLI arguments, example: `"--blocking-io"`
+
 script
 : list of commands to execute on remote machines over SSH


### PR DESCRIPTION
The rsync plugin recently got an additional parameter to specify additional rsync arguments. This PR updates the docs to reflect this change.