### PR TITLE
Update dns property to custom_dns property

### DIFF
--- a/content/drone-plugins/drone-docker/index.md
+++ b/content/drone-plugins/drone-docker/index.md
@@ -120,7 +120,7 @@ mirror
 bip=false
 : use for pass bridge ip
 
-dns
+custom_dns
 : set custom dns servers for the container
 
 storage_driver


### PR DESCRIPTION
dns is a reserved word now so the dns property is no longer being
converted to PLUGIN_DNS env var. Updating the name to enable passing
to the plugin