### PR TITLE
Adds Maven Auth plugin to index

### DIFF
--- a/content/robertstettner/drone-mvn-auth/index.md
+++ b/content/robertstettner/drone-mvn-auth/index.md
@@ -1,0 +1,93 @@
+---
+date: 2017-07-21T00:00:00+00:00
+title: Maven Auth
+author: robertstettner
+tags: [ maven, mvn, authentication ]
+repo: robertstettner/drone-mvn-auth
+logo: maven.svg
+image: robertstettner/drone-mvn-auth
+---
+The Maven Auth plugin can be used for generating the `settings.xml` with server authentication for a Maven repository. Please note that dependencies are saved in the `.m2` directory. The below pipeline configuration demonstrates usage: 
+
+```yaml
+pipeline:
+  authenticate:
+    image: robertstettner/drone-mvn-auth
+    servers:
+      - id: release
+        username: admin
+        password: R31e4sE
+      - id: snapshot
+        username: snap
+        password: crackle123
+    profiles:
+      - id: my-profile
+        repositories:
+          - id: myRepo
+            name: Repository for my libraries
+            url: http://maven.my.com
+            layout: default
+        plugin_repositories:
+          - id: myRepo
+            name: Repository for my libraries
+            url: http://maven.my.com
+            layout: default
+    active_profiles:
+      - my-profile
+```
+
+# Parameter Reference
+
+servers[]
+: the servers
+
+servers[].id
+: the server id
+
+servers[].username
+: the server username
+
+servers[].password
+: the server password
+
+profiles[]
+: the profiles
+
+profiles[].id
+: the profile id
+
+profiles[].repositories[]
+: the profile's repositories
+
+profiles[].repositories[].id
+: the profile's repository id
+
+profiles[].repositories[].name
+: the profile's repository name
+
+profiles[].repositories[].url
+: the profile's repository url
+
+profiles[].repositories[].layout
+: the profile's repository layout
+
+profiles[].plugin_repositories[]
+: the profile's plugin repositories
+
+profiles[].plugin_repositories[].id
+: the profile's plugin repository id
+
+profiles[].plugin_repositories[].name
+: the profile's plugin repository name
+
+profiles[].plugin_repositories[].url
+: the profile's plugin repository url
+
+profiles[].plugin_repositories[].layout
+: the profile's plugin repository layout
+
+active_profiles[]
+: the active profiles
+
+debug
+: debug mode (optional: set to `true` for verbose messages)

--- a/static/logos/maven.svg
+++ b/static/logos/maven.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 462 106" xmlns="http://www.w3.org/2000/svg">
+<g font-style="oblique" font-family="Verdana" font-weight="bold">
+<text font-size="96" transform="scale(0.943,1.06)" x="82" y="76">m</text>
+<text font-size="80" word-spacing="0" x="173" y="80"><tspan fill="#ff6804">a</tspan>ven</text>
+</g>
+</svg>


### PR DESCRIPTION
This PR adds documentation for the following plugin: https://github.com/robertstettner/drone-mvn-auth