### PR TITLE
Proposing Github search Downstream plugin

### DIFF
--- a/content/gboddin/drone-github-search-downstream/index.md
+++ b/content/gboddin/drone-github-search-downstream/index.md
@@ -51,9 +51,7 @@ pipeline:
     fork: true
 ```
 
-# Secret Reference
-
-This plugins supports sourcing sensitive parameters from the secret store. Example configuration sources the token from the secret store:
+This plugins also supports sourcing sensitive parameters from the secret store. Example configuration sources the token from the secret store:
 
 ```diff
 pipeline:
@@ -67,7 +65,7 @@ pipeline:
 +   secrets: [ drone_token, github_token ]
 ```
 
-# Parameter Reference
+# Secret Reference
 
 drone_token
 : drone server auth token
@@ -75,11 +73,16 @@ drone_token
 drone_server
 : drone server url
 
-github_query
-: Github repo search query
-
 github_token
 : Github authentication token
+
+# Parameter Reference
+
+drone_token
+: drone server auth token
+
+drone_server
+: drone server url
 
 fork
 : trigger new build numbers if true, else rebuild

--- a/content/gboddin/drone-github-search-downstream/index.md
+++ b/content/gboddin/drone-github-search-downstream/index.md
@@ -22,7 +22,6 @@ pipeline:
     github_query: "org:drone-plugins topic:drone-plugin"
     drone_server: https://drone.example.com
     drone_token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
-    fork: true
 ```
 
 Example target specific branches:
@@ -34,7 +33,6 @@ pipeline:
     github_query: "org:drone-plugins topic:drone-plugin"
     drone_server: https://drone.example.com
     drone_token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
-    fork: true
 +   branch: develop
 ```
 
@@ -48,7 +46,6 @@ pipeline:
 +   github_token: d8e8fca2dc0f896fd7cb4cb0031ba249
     drone_server: https://drone.example.com
     drone_token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
-    fork: true
 ```
 
 This plugins also supports sourcing sensitive parameters from the secret store. Example configuration sources the token from the secret store:
@@ -61,7 +58,6 @@ pipeline:
 -   github_token: d8e8fca2dc0f896fd7cb4cb0031ba249
     drone_server: https://drone.example.com
 -   drone_token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
-    fork: true
 +   secrets: [ drone_token, github_token ]
 ```
 
@@ -83,9 +79,6 @@ drone_token
 
 drone_server
 : drone server url
-
-fork
-: trigger new build numbers if true, else rebuild
 
 ignore_missing
 : continue triggering if build is not found

--- a/content/gboddin/drone-github-search-downstream/index.md
+++ b/content/gboddin/drone-github-search-downstream/index.md
@@ -1,0 +1,94 @@
+---
+date: 2018-05-10T00:00:00+00:00
+title: Github Search Downstream
+author: gboddin
+tags: [ infrastructure, trigger, drone, github ]
+logo: github.svg
+repo: gboddin/drone-github-search-downstream
+image: gboo/github-search-downstream
+---
+
+Use this plugin to trigger builds for a list of downstream repositories fetched
+from a Github repository search. This is useful when updates to a repository 
+have downstream impacts that should also be tested, and those repository are
+searchable on Github.
+
+This plugin is heavily based on the original Downstream plugin.
+
+```yaml
+pipeline:
+  trigger:
+    image: gboo/github-search-downsream
+    github_query: "org:drone-plugins topic:drone-plugin"
+    drone_server: https://drone.example.com
+    drone_token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+    fork: true
+```
+
+Example target specific branches:
+
+```diff
+pipeline:
+  trigger:
+    image: gboo/github-search-downsream
+    github_query: "org:drone-plugins topic:drone-plugin"
+    drone_server: https://drone.example.com
+    drone_token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+    fork: true
++   branch: develop
+```
+
+Example with Github authentication:
+
+```diff
+pipeline:
+  trigger:
+    image: gboo/github-search-downsream
+    github_query: "org:drone-plugins topic:drone-plugin"
++   github_token: d8e8fca2dc0f896fd7cb4cb0031ba249
+    drone_server: https://drone.example.com
+    drone_token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+    fork: true
+```
+
+# Secret Reference
+
+This plugins supports sourcing sensitive parameters from the secret store. Example configuration sources the token from the secret store:
+
+```diff
+pipeline:
+  trigger:
+    image: gboo/github-search-downsream
+    github_query: "org:drone-plugins topic:drone-plugin"
+-   github_token: d8e8fca2dc0f896fd7cb4cb0031ba249
+    drone_server: https://drone.example.com
+-   drone_token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+    fork: true
++   secrets: [ drone_token, github_token ]
+```
+
+# Parameter Reference
+
+drone_token
+: drone server auth token
+
+drone_server
+: drone server url
+
+github_query
+: Github repo search query
+
+github_token
+: Github authentication token
+
+fork
+: trigger new build numbers if true, else rebuild
+
+ignore_missing
+: continue triggering if build is not found
+
+wait
+: wait for any currently running builds to finish if true, else fails
+
+timeout
+: how long to wait on any currently running builds defaults to 60 seconds


### PR DESCRIPTION
Is just an extend of `plugins/downstream` ( cc @tboerger ) but allows a list of repositories from a Github search instead of a provided list : 

```
pipeline:
 trigger-downstream:
   image: gboo/github-search-downstream
   github_query: "org:drone-plugins topic:drone-plugin"
   branch: master
   drone_server: https://hold-on.nobody.run
   secrets: [ github_token, drone_token ]
```

Useful if you have lots of repositories tagged by a topic that you want to test in some circumstances for instance