### PR TITLE
Proposing Github PR control

### DIFF
--- a/content/gboddin/drone-github-pr/index.md
+++ b/content/gboddin/drone-github-pr/index.md
@@ -19,6 +19,8 @@ pipeline:
     github_token: d8e8fca2dc0f896fd7cb4cb0031ba249
     action: comment
     message: "Commenting a PR !"
+    when:
+      event: pull_request
 ```
 
 # Close a pull request
@@ -30,6 +32,8 @@ pipeline:
     github_token: d8e8fca2dc0f896fd7cb4cb0031ba249
     action: close
     message: "Closing a PR !"
+    when:
+      event: pull_request
 ```
 
 # Merge a pull request
@@ -43,6 +47,8 @@ pipeline:
     github_token: d8e8fca2dc0f896fd7cb4cb0031ba249
     action: merge
     message: "Merging a PR !"
+    when:
+      event: pull_request
 ```
 
 

--- a/content/gboddin/drone-github-pr/index.md
+++ b/content/gboddin/drone-github-pr/index.md
@@ -1,0 +1,69 @@
+---
+date: 2018-17-05T00:00:00+00:00
+title: Github PR Control
+author: gboddin
+tags: [ infrastructure, trigger, drone, github ]
+logo: github.svg
+repo: gboddin/drone-github-pr
+image: gboo/github-pr
+---
+
+Use this plugin to interact with Github pull requests, it supports 3 modes of operation.
+
+# Comment a pull request
+
+```yaml
+pipeline:
+  comment-pr:
+    image: gboo/github-pr
+    github_token: d8e8fca2dc0f896fd7cb4cb0031ba249
+    action: comment
+    message: "Commenting a PR !"
+```
+
+# Close a pull request
+
+```yaml
+pipeline:
+  close-pr:
+    image: gboo/github-pr
+    github_token: d8e8fca2dc0f896fd7cb4cb0031ba249
+    action: close
+    message: "Closing a PR !"
+```
+
+# Merge a pull request
+
+Three methods are supported for merging : `merge`, `squash`, `rebase`.
+
+```yaml
+pipeline:
+  merge-pr:
+    image: gboo/github-pr
+    github_token: d8e8fca2dc0f896fd7cb4cb0031ba249
+    action: merge
+    message: "Merging a PR !"
+```
+
+
+# Secret Reference
+
+github_token
+: Github OAuth authentication token.
+
+# Parameter Reference
+
+action
+: Selects what action to perform on the pull request ( One of `comment`, `close`, `merge`, `rebase`, `squash` ).
+
+message
+: The content of the comment left on the pull request, but also the merge commit message. The current commit message is used by default.
+
+number
+: The pull request number to interact with. The current PR number is used by default.
+
+repo_owner
+: The repository owner to interact with. The current repository owner is used by default.
+
+repo_name
+: The repository name to interact with. The current repository name is used by default.


### PR DESCRIPTION
Useful if you want to interact with a PR during or at the end of a build.

It supports 3 modes : 

- comment
- close
- merge ( and rebase and squash )

# Examples
 
## Comment a pull request

```yaml
pipeline:
  comment-pr:
    image: gboo/github-pr
    github_token: d8e8fca2dc0f896fd7cb4cb0031ba249
    action: comment
    message: "Commenting a PR !"
    when:
      event: pull_request
```

## Close a pull request

```yaml
pipeline:
  close-pr:
    image: gboo/github-pr
    github_token: d8e8fca2dc0f896fd7cb4cb0031ba249
    action: close
    message: "Closing a PR !"
    when:
      event: pull_request
```

## Merge a pull request

```yaml
pipeline:
  merge-pr:
    image: gboo/github-pr
    github_token: d8e8fca2dc0f896fd7cb4cb0031ba249
    action: merge
    message: "Merging a PR !"
    when:
      event: pull_request
```

