### PR TITLE
Adds build.deployTo to the drone-slack documentation. This was added …

### DIFF
--- a/content/drone-plugins/drone-slack/index.md
+++ b/content/drone-plugins/drone-slack/index.md
@@ -149,6 +149,9 @@ build.started
 build.pull
 : pull request number (empty string if not a pull request)
 
+build.deployTo
+: env that the build was deployed to.
+
 # Template Function Reference
 
 uppercasefirst


### PR DESCRIPTION
…in PR https://github.com/drone-plugins/drone-slack/pull/55 for drone-slack.