### PR TITLE
Changed name to Enteprise WeChat

### DIFF
--- a/content/clem109/drone-wechat/index.md
+++ b/content/clem109/drone-wechat/index.md
@@ -1,14 +1,14 @@
 ---
 date: 2018-02-19T00:00:00+00:00
-title: Wechat for Work
+title:  企业微信 Enterprise WeChat
 author: clem109
-tags: [ notifications, chat, wechat ]
+tags: [ notifications, chat, enterprise wechat ]
 logo: wechat.svg
 repo: clem109/drone-wechat
 image: clem109/drone-wechat
 ---
 
-Drone plugin for WeChat for Work to show build notifications.
+Drone plugin for Enterprise WeChat to show build notifications.
 
 The following is a sample configuration in your .drone.yml file:
 


### PR DESCRIPTION
Edited the name WeChat for Work to  Enterprise WeChat, this makes it clearer for Chinese users as this is the correct translation and is different from normal WeChat.