### PR TITLE
Docs: Fix from_secret name in example

### DIFF
--- a/content/drone-plugins/drone-downstream/index.md
+++ b/content/drone-plugins/drone-downstream/index.md
@@ -60,7 +60,7 @@ steps:
   settings:
     server: https://drone.example.com
     token:
-      from_secret: docker_token
+      from_secret: drone_token
     fork: true
     repositories:
       - octocat/Hello-World


### PR DESCRIPTION
The secret name referenced in the documentation example is `docker_token`, but based on the context, it seems like it should be something like `drone_token`.
