### PR TITLE
github-release: add required scope documentation for access token

### DIFF
--- a/content/drone-plugins/drone-github-release/index.md
+++ b/content/drone-plugins/drone-github-release/index.md
@@ -84,7 +84,10 @@ steps:
 # Parameter Reference
 
 api_key
-: GitHub oauth token with public_repo or repo permission
+: GitHub oauth token with public_repo or repo permission. If you create your token,
+ensure you select the correct scope. For private repositories to must select `repo`
+while public repositories only requires `public_repo`. You can read more about creating a
+personal access token [here](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/).
 
 files
 : files to upload to GitHub Release, globs are allowed


### PR DESCRIPTION
Should fix https://github.com/drone-plugins/drone-github-release/issues/25