### PR TITLE
Doc updates on source and target parameters

### DIFF
--- a/content/drone-plugins/drone-s3/index.md
+++ b/content/drone-plugins/drone-s3/index.md
@@ -41,6 +41,18 @@ steps:
     target: /target/location
 ```
 
+Use the build number in the S3 target prefix:
+
+```yaml
+steps:
+- name: upload
+  image: plugins/s3
+  settings:
+    bucket: my-bucket-name
+    source: public/**/*
+    target: /target/location/${DRONE_BUILD_NUMBER}
+```
+
 Override the default acl and region:
 
 ```yaml
@@ -117,7 +129,7 @@ acl
 : access to files that are uploaded (`private`, `public-read`, etc)
 
 source
-: source location of the files, using a glob matching pattern
+: source location of the files, using a glob matching pattern. Location must be within the drone workspace.
 
 target
 : target location of files in the bucket


### PR DESCRIPTION
* Added example on using DRONE_BUILD_NUMBER, since I think this is a common use case, and the syntax for general variable substitution for plugin parameters isn't well documented.
* Added clarification that the source location must be in the drone workspace. This makes sense since the plugin runs in its own container, but can be easy to gloss over. 

Something I wasn't sure of - can you also upload artifacts from a shared volume which is mounted outside the workspace?