### PR TITLE
ECR documentation needs custom_dns since this plugin is combined with the docker plugin

### DIFF
--- a/content/drone-plugins/drone-ecr/index.md
+++ b/content/drone-plugins/drone-ecr/index.md
@@ -135,7 +135,7 @@ mirror
 bip=false
 : use for pass bridge ip
 
-dns
+custom_dns
 : set custom dns servers for the container
 
 storage_driver


### PR DESCRIPTION
I tried with just `dns` and it was still failing, but `custom_dns` (as described in the docker plugin's docs page) works perfectly.