### PR TITLE
typo: from_secret not from_password

### DIFF
--- a/content/drone-plugins/drone-pypi/index.md
+++ b/content/drone-plugins/drone-pypi/index.md
@@ -55,7 +55,7 @@ steps:
 +    username:
 +      from_secret: pypi_username
 +    password:
-+      from_password: pypi_password
++      from_secret: pypi_password
 ```
 
 # Parameter Reference


### PR DESCRIPTION
In the docs it uses `from_password` which is not valid, it should be `from_secret`.