### PR TITLE
Use singular titles for plugin authors

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -29,6 +29,7 @@ menu:
 defaultContentLanguage: en
 defaultContentLanguageInSubdir: false
 enableMissingTranslationPlaceholders: false
+pluralizeListTitles: false
 
 languages:
   en:


### PR DESCRIPTION
My original motivation was to fix the pluralization of "Pelotech," which Hugo turned into "Peloteches," but pluralization in general doesn't seem appropriate for the plugin index. It makes sense for something like "posts," but in this case we're looking at author names, not categories.