### PR TITLE
drone-gitea-release: indent error in yaml of checksum example

### DIFF
--- a/content/drone-plugins/drone-gitea-release/index.md
+++ b/content/drone-plugins/drone-gitea-release/index.md
@@ -39,7 +39,7 @@ steps:
     files:
       - dist/*
       - bin/binary.exe
-   checksum:
+    checksum:
       - md5
       - sha1
       - sha256


### PR DESCRIPTION
lack of a whitespace