### PR TITLE
Clarify Access Token Type

### DIFF
--- a/content/drone-plugins/drone-gitea-release/index.md
+++ b/content/drone-plugins/drone-gitea-release/index.md
@@ -87,6 +87,8 @@ steps:
 api_key
 : Gitea application token
 
+**NOTE**: This is under `https://<<instance>>/user/settings/applications` the **first** type of access token.  It is **NOT** the same as the `DRONE_GITEA_CLIENT_SECRET` that drone uses (oauth token).
+
 base_url
 : Base URL of the Gitea instance
 


### PR DESCRIPTION
There are a lot of people getting confused by the fact that there are multiple access token types (app auth token, access token, oauth token).  I'll admit it, I did too, and got very frustrated with the plugin.  I was about to fork and "fix" the plugin when I worked it out.

See https://github.com/drone-plugins/drone-gitea-release/issues/7 for many people hitting this, so much so that the author locked the thread because they were getting too much "this doesn't work" type issues.

By this one small tip, hopefully we can save many people a lot of pain.