### PR TITLE
Update url for getting started with slack webhooks

### DIFF
--- a/content/drone-plugins/drone-slack/index.md
+++ b/content/drone-plugins/drone-slack/index.md
@@ -118,7 +118,7 @@ steps:
 # Parameter Reference
 
 webhook
-: incoming [webhook url](https://my.slack.com/services/new/incoming-webhook) for posting to a channel
+: incoming [webhook url](https://api.slack.com/messaging/webhooks#getting-started) for posting to a channel
 
 channel
 : messages sent to the above webhook are posted here


### PR DESCRIPTION
The currently linked implementation leads to an error "invalid_token" when trying to use with the plugin. 
The approach that must be followed for creation of the Slack Webhook needs to be as a Slack App. 
Hence, I swapped out the link here so future new starters set up with the correct Webhook and aren't stuck in the same rabbithole as I was.

Ref:https://discourse.drone.io/t/invalid-token-error-message-when-trying-to-use-slack-notifications/8391/2