### PR TITLE
5 new plugins to include in the index

### DIFF
--- a/content/OSSHelp/drone-alertmanager/index.md
+++ b/content/OSSHelp/drone-alertmanager/index.md
@@ -14,7 +14,7 @@ This plugin creates and removes silences in AlertManager.
 
 # Usage examples
 
-An example of use in a build step for "typical" container deployment:
+An example of use in a build step for "typical" container deployment. Adding the silence with required matchers:
 
 ``` yaml
 - name: add silence
@@ -27,9 +27,12 @@ An example of use in a build step for "typical" container deployment:
       duration: 600
       job: '^clientname$'
       instance: '^server-\w+.+'
+```
 
-    <# Deploy steps #>
+Then, after step with deployment, remove the silence:
 
+
+```yaml
   - name: remove silence
     image: osshelp/drone-alertmanager
     settings:

--- a/content/OSSHelp/drone-alertmanager/index.md
+++ b/content/OSSHelp/drone-alertmanager/index.md
@@ -1,0 +1,119 @@
+---
+version: '1.1.2'
+date: 2021-02-06-T00:00:00+00:00
+title: Alertmanager
+author: OSSHelp
+tags: [ prometheus, alertmanager, silences ]
+logo: prometheus.svg
+repo: osshelp/drone-alertmanager
+image: osshelp/drone-alertmanager
+---
+
+This plugin creates and removes silences in AlertManager.
+
+
+# Usage examples
+
+An example of use in a build step for "typical" container deployment:
+
+``` yaml
+- name: add silence
+    image: osshelp/drone-alertmanager
+    settings:
+      urls:
+        - https://clientname.monitoring.fqdn/alertmanager
+      action: create
+      template: default
+      duration: 600
+      job: '^clientname$'
+      instance: '^server-\w+.+'
+
+    <# Deploy steps #>
+
+  - name: remove silence
+    image: osshelp/drone-alertmanager
+    settings:
+      urls:
+        - https://clientname.monitoring.fqdn/alertmanager
+      action: delete
+    when:
+      status:
+        - success
+        - failure
+```
+
+# Templates
+
+## default
+
+So far, the main and only template.
+
+``` json
+{
+  "id": null,
+  "createdBy": "drone/alertmanager",
+  "startsAt": "2020-11-14T02:27:07.429780Z",
+  "endsAt": "2020-11-14T02:29:07.429780Z",
+  "comment": "Created for build#42 of orgname/reponame, see http://ci.server.fqdn/link/to/build",
+  "matchers": [
+    {
+      "isRegex": true,
+      "name": "job",
+      "value": "^clientname$"
+    },
+    {
+      "isRegex": true,
+      "name": "instance",
+      "value": "^server-\\w+.+"
+    }
+  ]
+}
+```
+
+# Parameter Reference
+
+## Modes
+
+action
+: creates or removes silences (values: create, delete)
+
+## Other
+
+urls
+: list of urls to send a request
+
+duration
+: duration of added silence (only for create action)
+
+template
+: one of the available request body templates
+
+strict_match
+: checking for an exact match of all alert conditions (false by default)
+
+valid_response_codes
+: list of expected HTTP response codes
+
+headers
+: additional request headers
+
+custom_template
+: arbitrary request body (Jinja syntax with access to environment variables is supported)
+
+username and password
+: credentials for HTTP authorization
+
+skip_verify
+: disable SSL certificate verification (for self-signed ones)
+
+follow_redirects
+: follow a 301/302 redirect
+
+timeout
+: maximum time to wait for a response (in seconds)
+
+## Links
+
+* [Alertmanager Documentation](https://prometheus.io/docs/alerting/latest/alertmanager/)
+* [Plugin sources at Github](https://github.com/OSSHelp/drone-alertmanager)
+* [Plugin image at DockerHub](https://hub.docker.com/r/osshelp/drone-alertmanager)

--- a/content/OSSHelp/drone-git-mirror/index.md
+++ b/content/OSSHelp/drone-git-mirror/index.md
@@ -1,0 +1,68 @@
+---
+version: '0.0.1'
+date: 2021-02-06-T00:00:00+00:00
+title: Git mirror
+author: OSSHelp
+tags: [ git, mirror, push ]
+logo: git.svg
+repo: osshelp/drone-git-mirror
+image: osshelp/drone-git-mirror
+---
+
+The plugin is for mirroring Git repositories to the external ones.
+
+# Usage examples
+
+``` yaml
+steps:
+  - name: mirror
+    image: osshelp/drone-git-mirror
+    settings:
+      target_repo: git@github.com:OSSHelp/some-repo.git
+      ssh_key:
+        from_secret: git-mirror-private-key
+```
+
+# Parameter Reference
+
+target_repo
+: SSH clone URL of target repo
+
+ssh_key
+: Private key with R/W permissions to use for interacting with `target_repo`
+
+git_email
+: E-mail that will be used while pushing changes (default: `drone@osshelp`)
+
+git_name
+: Name that will be used while pushing changes (default: `Drone CI`)
+
+ignore_errors
+: If set to `true` the plugin will try to ignore all occurring errors to prevent build failing because of itself (default: `false`)
+
+mirror_ignore_list
+: If this file is found in repo root - it contents will be used as excludement list for mirroring (default `.mirror_ignore`)
+
+# FAQ
+
+## How to exclude unwanted files from sync
+
+By default plugin will try to mirror repository contents to `target_repo` "as is". If you want to exclude some files from mirroring you need to create a file, named `.mirror_ignore` (if not overwritten with `mirror_ignore_list` variable) in repo root. Describe wanted and unwanted files and directories inside as if you are preparing a file for using with `--exclude-from` rsync flag (GNU tar way). For example:
+
+```
+.drone.yml
+.mirror_ignore
+file1.txt
+dir1/*
+dir2
+```
+
+## How to delete excluded files or trash branches from remote repo
+
+Files, excluded with `mirror_ignore_list` will not be automatically removed from remote repo. Neither do branches. No plans of implementing such functionality.
+
+
+# Links
+
+* [Plugin sources at Github](https://github.com/OSSHelp/drone-git-mirror)
+* [Plugin image at DockerHub](https://hub.docker.com/r/osshelp/drone-git-mirror)

--- a/content/OSSHelp/drone-linter/index.md
+++ b/content/OSSHelp/drone-linter/index.md
@@ -1,0 +1,127 @@
+---
+version: '1.3.2'
+date: 2021-02-06-T00:00:00+00:00
+title: Linter
+author: OSSHelp
+tags: [ linter, hadolint, shellcheck, yamllint, flake8, markdownlint ]
+logo: git.svg
+repo: osshelp/drone-linter
+image: osshelp/drone-linter
+---
+
+This plugin contains following linters:
+
+* hadolint (Dockerfile)
+* shellcheck (bash scripts)
+* yamllint (yaml)
+* flake8 (python scripts)
+* markdownlint (markdown)
+
+# Usage examples
+
+## Find and lint files automatically
+
+``` yaml
+steps:
+  - name: lint
+    image: osshelp/drone-linter
+```
+
+## Specific files to check
+
+``` yaml
+steps:
+  - name: lint
+    image: osshelp/drone-linter
+    settings:
+      yml_files:
+        - file1.yml
+        - dir/file2.yml
+      sh_files:
+        - entrypoint.sh
+      dockerfiles:
+        - Dockerfile
+      markdown_files:
+        - README.md
+      python_files:
+        - test.py
+```
+
+## Skip checks
+
+``` yaml
+steps:
+  - name: lint
+    image: osshelp/drone-linter
+    settings:
+      skip_yml: true
+      skip_sh: true
+      skip_dockerfile: true
+      skip_markdown: true
+      skip_python: true
+```
+
+## Exclude files by exclude_regex
+
+``` yaml
+steps:
+  - name: lint
+    image: osshelp/drone-linter
+    settings:
+      exclude_regex: '(regex1|regex2)'
+```
+
+# Parameter Reference
+
+## Specific files
+
+yml_files
+: list of YAML files or to check
+
+sh_files
+: list of shell scripts to check
+
+dockerfiles
+: list of Dockerfiles to check
+
+markdown_files
+: list of files with Markdown syntax inside to check
+
+python_files
+: list of python scripts to check
+
+## Disable linters
+
+skip_yml
+: skip checking YAML files
+
+skip_sh
+: skip checking shell scripts
+
+skip_dockerfile
+: skip checking Dockerfiles
+
+skip_markdown
+: skip checkimg MD files
+
+skip_python
+: skip checking python scripts
+
+## Excluding files
+
+exclude_regex
+: regular expression to to exclude files from checking
+
+
+## Linters documentations
+
+- [hadolint](https://github.com/hadolint/hadolint)
+- [shellcheck](https://github.com/koalaman/shellcheck)
+- [yamllint](https://yamllint.readthedocs.io/en/stable/)
+- [flake8](http://flake8.pycqa.org/en/latest/user/error-codes.html)
+- [markdownlint](https://github.com/DavidAnson/markdownlint)
+
+## Links
+
+* [Plugin sources at Github](https://github.com/OSSHelp/drone-linter)
+* [Plugin image at DockerHub](https://hub.docker.com/r/osshelp/drone-linter)

--- a/content/OSSHelp/drone-linter/index.md
+++ b/content/OSSHelp/drone-linter/index.md
@@ -13,9 +13,10 @@ This plugin contains following linters:
 
 * hadolint (Dockerfile)
 * shellcheck (bash scripts)
-* yamllint (yaml)
-* flake8 (python scripts)
-* markdownlint (markdown)
+* yamllint (YAML files)
+* flake8 (Python scripts)
+* markdownlint (Markdown)
+* jsonlint (JSON files)
 
 # Usage examples
 
@@ -45,6 +46,8 @@ steps:
         - README.md
       python_files:
         - test.py
+      json_files:
+        - file.json
 ```
 
 ## Skip checks
@@ -59,6 +62,7 @@ steps:
       skip_dockerfile: true
       skip_markdown: true
       skip_python: true
+      skip_json: true
 ```
 
 ## Exclude files by exclude_regex
@@ -90,6 +94,9 @@ markdown_files
 python_files
 : list of python scripts to check
 
+json_files
+: list of JSON files to check
+
 ## Disable linters
 
 skip_yml
@@ -105,7 +112,10 @@ skip_markdown
 : skip checkimg MD files
 
 skip_python
-: skip checking python scripts
+: skip checking Python scripts
+
+skip_json
+: skip checking JSON files
 
 ## Excluding files
 
@@ -115,11 +125,12 @@ exclude_regex
 
 ## Linters documentations
 
-- [hadolint](https://github.com/hadolint/hadolint)
-- [shellcheck](https://github.com/koalaman/shellcheck)
-- [yamllint](https://yamllint.readthedocs.io/en/stable/)
-- [flake8](http://flake8.pycqa.org/en/latest/user/error-codes.html)
-- [markdownlint](https://github.com/DavidAnson/markdownlint)
+* [hadolint](https://github.com/hadolint/hadolint)
+* [shellcheck](https://github.com/koalaman/shellcheck)
+* [yamllint](https://yamllint.readthedocs.io/en/stable/)
+* [flake8](http://flake8.pycqa.org/en/latest/user/error-codes.html)
+* [markdownlint](https://github.com/DavidAnson/markdownlint)
+* [jsonlint](https://github.com/zaach/jsonlint)
 
 ## Links
 

--- a/content/OSSHelp/drone-molecule/index.md
+++ b/content/OSSHelp/drone-molecule/index.md
@@ -1,0 +1,113 @@
+---
+version: '1.4.2'
+date: 2021-02-06-T00:00:00+00:00
+title: Molecule
+author: OSSHelp
+tags: [ molecule, ansible, testinfra ]
+logo: ansible.svg
+repo: osshelp/drone-molecule
+image: osshelp/drone-molecule
+---
+
+Plugin for testing Ansible roles via Molecule (+testinfra).
+
+# Usage examples
+
+``` yaml
+---
+kind: pipeline
+name: test
+
+steps:
+  - name: test
+    image: osshelp/drone-molecule
+    environment:
+      LXD_REMOTE_PASSWORD:
+        from_secret: lxd_remote_password
+    settings:
+      action: test
+
+---
+kind: pipeline
+name: publish
+
+depends_on: [test]
+trigger:
+  status: [success]
+  event: [push, tag]
+  ref:
+    - refs/heads/*
+    - refs/tags/*
+
+steps:
+  - name: publish
+    image: osshelp/drone-molecule
+    environment:
+      MINIO_USER:
+        from_secret: minio_user
+      MINIO_SECRET:
+        from_secret: minio_secret
+    settings:
+      action: upload
+```
+
+# Parameter Reference
+
+## Modes
+
+action
+: just test, upload or test plus upload (values: test, upload, release)
+
+## Other
+
+scenario
+: molecule scenario (default: `default`)
+
+lxd_remote_host and lxd_remote_port
+: LXD connection parameters
+
+release_directory
+: the name of the local temporary folder to create an archive with the role
+
+ansible_requirements
+: The path to the requirements file that will be used to load roles. (default: `requirements.yml`)
+
+ansible_profiler: an option to control ansible-profiler (default: `true`)
+
+ansible_errors_fatal
+: whether to consider all errors during the execution of roles at the stage of rolling the playbook fatal (default: `true`)
+
+minio_alias
+: the name that will be used when generating the variable for minio-client. (default: `remote`)
+
+minio_host and minio_bucket
+: minio connection parameters
+
+upload_prefix
+: nested directories inside bucket
+
+upload_as
+: override archive name with role
+
+minio_debug
+: debug mode for minio
+
+release_alias
+: upload alias (see "Release aliases below")
+
+debug
+: debug mode
+
+### Release aliases
+
+Here are examples of how release_alias option works by default (w/out specific value):
+
+* on tag -> alias will be `stable`
+* on push to master branch -> alias will be `latest`
+* on push to any other branch -> branch name will be used as an alias
+
+## Links
+
+* [Molecule Documentation](https://molecule.readthedocs.io/)
+* [Plugin sources at Github](https://github.com/OSSHelp/drone-molecule)
+* [Plugin image at DockerHub](https://hub.docker.com/r/osshelp/drone-molecule)

--- a/content/OSSHelp/drone-prometheus-alerts/index.md
+++ b/content/OSSHelp/drone-prometheus-alerts/index.md
@@ -1,0 +1,78 @@
+---
+version: '1.0.0'
+date: 2021-02-19-T00:00:00+00:00
+title: Prometheus Alerts
+author: OSSHelp
+tags: [ prometheus, alerts, promtool, testing ]
+logo: prometheus.svg
+repo: osshelp/drone-prometheus-alerts
+image: osshelp/drone-prometheus-alerts
+---
+
+This plugin helps with testing alerting and recording rules for Prometheus.
+
+# Usage examples
+
+# Find and lint files automatically
+
+``` yaml
+steps:
+  - name: check and test alertrules
+    image: osshelp/drone-prometheus-alerts
+```
+
+## Specific files to check and specific tests
+
+``` yaml
+steps:
+  - name: check and test alertrules
+    image: osshelp/drone-prometheus-alerts
+    settings:
+      alertrules_files:
+        - alerts/file1.yml
+        - alerts/file2.yml
+      alertrules_tests:
+        - tests/test1.yml
+```
+
+## Exclude files by exclude_regex
+
+``` yaml
+steps:
+  - name: check and test alertrules
+    image: osshelp/drone-prometheus-alerts
+    settings:
+      exclude_regex: '(regex1|regex2)'
+```
+
+# Parameter Reference
+
+alertrules_dir
+: Directory with alertrules files ("alerts" by default)
+
+alertrules_files
+: If empty string files will be searched in the `alertrules_dir`
+
+alertrules_tests_dir
+: Directory with tests ("tests" by default)
+
+alertrules_tests
+: If empty string files will be searched in the `alertrules_tests_dir`
+
+exclude_regex
+: Regular expression to exclude files from checking and testing ("^NO_EXCLUDE_FILES\$" by default)
+
+verbose
+: Show verbose output, including promtool results (false by default)
+
+# FAQ
+
+## Why it fails with alerts without tests?
+
+Using alerting rules without corresponding testing is considered a very bad idea. One day you can break your alerting without even noticing it. The consequences you can imagine by yourself. So, read the [official docs on promtool](https://prometheus.io/docs/prometheus/latest/configuration/unit_testing_rules/) and add tests for your alerting rules.
+
+## Links
+
+* [Prometheus documentation](https://prometheus.io/docs/prometheus/latest/configuration/unit_testing_rules/)
+* [Plugin sources at Github](https://github.com/OSSHelp/drone-prometheus-alerts)
+* [Plugin image at DockerHub](https://hub.docker.com/r/osshelp/drone-prometheus-alerts)

--- a/static/logos/prometheus.svg
+++ b/static/logos/prometheus.svg
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   width="115.333px"
+   height="114px"
+   viewBox="0 0 115.333 114"
+   enable-background="new 0 0 115.333 114"
+   xml:space="preserve"
+   sodipodi:docname="prometheus_logo_orange.svg"
+   inkscape:version="0.92.1 r15371"><metadata
+     id="metadata4495"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+     id="defs4493" /><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1484"
+     inkscape:window-height="886"
+     id="namedview4491"
+     showgrid="false"
+     inkscape:zoom="5.2784901"
+     inkscape:cx="60.603667"
+     inkscape:cy="60.329656"
+     inkscape:window-x="54"
+     inkscape:window-y="7"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="Layer_1" /><g
+     id="Layer_2" /><path
+     style="fill:#e6522c;fill-opacity:1"
+     inkscape:connector-curvature="0"
+     id="path4486"
+     d="M 56.667,0.667 C 25.372,0.667 0,26.036 0,57.332 c 0,31.295 25.372,56.666 56.667,56.666 31.295,0 56.666,-25.371 56.666,-56.666 0,-31.296 -25.372,-56.665 -56.666,-56.665 z m 0,106.055 c -8.904,0 -16.123,-5.948 -16.123,-13.283 H 72.79 c 0,7.334 -7.219,13.283 -16.123,13.283 z M 83.297,89.04 H 30.034 V 79.382 H 83.298 V 89.04 Z M 83.106,74.411 H 30.186 C 30.01,74.208 29.83,74.008 29.66,73.802 24.208,67.182 22.924,63.726 21.677,60.204 c -0.021,-0.116 6.611,1.355 11.314,2.413 0,0 2.42,0.56 5.958,1.205 -3.397,-3.982 -5.414,-9.044 -5.414,-14.218 0,-11.359 8.712,-21.285 5.569,-29.308 3.059,0.249 6.331,6.456 6.552,16.161 3.252,-4.494 4.613,-12.701 4.613,-17.733 0,-5.21 3.433,-11.262 6.867,-11.469 -3.061,5.045 0.793,9.37 4.219,20.099 1.285,4.03 1.121,10.812 2.113,15.113 C 63.797,33.534 65.333,20.5 71,16 c -2.5,5.667 0.37,12.758 2.333,16.167 3.167,5.5 5.087,9.667 5.087,17.548 0,5.284 -1.951,10.259 -5.242,14.148 3.742,-0.702 6.326,-1.335 6.326,-1.335 l 12.152,-2.371 c 10e-4,-10e-4 -1.765,7.261 -8.55,14.254 z" /></svg>


### PR DESCRIPTION
Hello.

This PR contains information about following plugins:

* [OSSHelp/drone-alertmanager](https://hub.docker.com/r/osshelp/drone-alertmanager)
* [OSSHelp/drone-git-mirror](https://hub.docker.com/r/osshelp/drone-git-mirror)
* [OSSHelp/drone-linter](https://hub.docker.com/r/osshelp/drone-linter)
* [OSSHelp/drone-molecule](https://hub.docker.com/r/osshelp/drone-molecule)
* [OSSHelp/drone-prometheus-alerts](https://hub.docker.com/r/osshelp/drone-prometheus-alerts)

Plus new logo for:

- Prometheus

Please, include these in the public catalog of plugins for Drone CI. If there is anything needed to be changed, please, let me know.

Thank you.
