### PR TITLE
Fix Dockerfile workspace/workdir typo

### DIFF
--- a/content/drone-plugins/drone-docker/index.md
+++ b/content/drone-plugins/drone-docker/index.md
@@ -189,7 +189,7 @@ Using a `Dockerfile` like:
 
 ```
 FROM golang as builder
-WORKSPACE /go/src/github.com/foo/bar
+WORKDIR /go/src/github.com/foo/bar
 RUN CGO_ENABLED=0 GOOS=linux go build -o demo main.go
 
 FROM scratch as production


### PR DESCRIPTION
Fixes https://github.com/drone-plugins/drone-docker/issues/282