### PR TITLE
drone-ecr: adding new scan_on_push parameter to the documentation

### DIFF
--- a/content/drone-plugins/drone-ecr/index.md
+++ b/content/drone-plugins/drone-ecr/index.md
@@ -150,3 +150,6 @@ storage_driver
 
 build_args
 : custom arguments passed to docker build
+
+scan_on_push
+: boolean of whether to enable automatic ECR images vulnerabilities scanning for repository if it was created with create_repository=`true`, defaults to `false`


### PR DESCRIPTION
* adding new scan_on_push parameter to the documentation, which related to this merged feature -  https://github.com/drone-plugins/drone-docker/pull/300