### PR TITLE
bumps ansible plugin version

### DIFF
--- a/content/drone-plugins/drone-ansible/index.md
+++ b/content/drone-plugins/drone-ansible/index.md
@@ -17,7 +17,7 @@ name: default
 
 steps:
 - name: check ansible syntax
-  image: plugins/ansible:1
+  image: plugins/ansible:3
   environment:
     additional_var:
       from_secret: additional_var
@@ -32,7 +32,7 @@ steps:
     - pull_request
 
 - name: apply ansible playbook
-  image: plugins/ansible:1
+  image: plugins/ansible:3
   environment:
     additional_var:
       from_secret: additional_var


### PR DESCRIPTION
Docs reference an old version of the Ansible plugin which is quite buggy. As a newcomer it took me some time to figure out that there was another, newer version of the plugin available.

This PR makes v3 the default from now on.