### PR TITLE
Add drone-plugin-dco to the index

### DIFF
--- a/plugins/dco/content.yaml
+++ b/plugins/dco/content.yaml
@@ -1,0 +1,25 @@
+title: DCO
+author: algernon
+tags:
+  - analysis
+  - report
+  - test
+repo: https://git.madhouse-project.org/algernon/drone-plugin-dco
+image: https://hub.docker.com/r/algernon/drone-plugin-dco
+license: GNU General Public License v3.0
+readme: https://git.madhouse-project.org/algernon/drone-plugin-dco/src/branch/master/README.md
+description: The DCO plugin enforces the Developer Certificate of Origin.
+example: |
+  kind: pipeline
+  name: default
+
+  steps:
+  - name: dco
+    image: algernon/drone-plugin-dco
+properties:
+  debug:
+    type: boolean
+    defaultValue: false
+    description: whether to enable debug mode.
+    secret: false
+    required: false

--- a/plugins/dco/original.md
+++ b/plugins/dco/original.md
@@ -1,0 +1,40 @@
+---
+date: 2018-09-14T00:00:00+00:00
+title: drone-plugin-dco
+author: algernon
+tags: [ test ]
+logo: term.svg
+repo: https://git.madhouse-project.org/algernon/drone-plugin-dco
+image: algernon/drone-plugin-dco
+---
+
+The `drone-plugin-dco` plugin can be used to enforce the [Developer Certificate of Origin][dco], by making sure that all commits conform to it. It verifies both that a `Signed-off-by` line is present, and that it is signed off by the commit author. Multiple signed-off lines are supported, but the plugin only verifies that the commit author is among them, it does not attempt to verify the rest.
+
+ [drone]: https://drone.io/
+ [dco]: https://developercertificate.org/
+
+The pipeline below demonstrates its usage:
+
+```yaml
+pipeline:
+  dco:
+    image: algernon/drone-plugin-dco
+```
+
+If, for some reason the plugin misbehaves, or fails with an error, one can turn on debugging before reporting the problem:
+
+```diff
+pipeline:
+  dco:
+    image: algernon/drone-plugin-dco
++   debug: true
+```
+
+# Parameter Reference
+
+debug
+: Enable debug logging, for the purpose of reporting errors.
+
+# Limitations
+
+The plugin only works with git-based repositories at the moment.


### PR DESCRIPTION
This obsoletes #150.

I had to open a new PR, because the fork #150 was made from has been deleted since, and re-forking didn't link it back, so couldn't update the original PR.