### PR TITLE
Add Stalebot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,10 @@
+daysUntilStale: 30
+daysUntilClose: 5
+exemptLabels:
+  - security
+staleLabel: wontfix
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+closeComment: false


### PR DESCRIPTION
To help us maintain a clean backlog of PR's and to give high impact PR's a better chance to be seen, reviewed and merged, we need an automated way of clearing out any PR's that haven't seen any action in a while.

_This initial integration of Stalebot is an experiment._