### PR TITLE
Clarify docker plugin parameter dockerfile is a path (not just file name)

### DIFF
--- a/plugins/docker/original.md
+++ b/plugins/docker/original.md
@@ -245,7 +245,7 @@ tags
 : repository tag for the image
 
 dockerfile
-: dockerfile to be used, defaults to Dockerfile
+: path to the dockerfile to be used, defaults to Dockerfile
 
 <!--
 auth


### PR DESCRIPTION
I encountered errors and went on an adventure enabling logs, diving into the several podman container in container layers to ultimately find the raw docker command executed. With some added words, this info can help the next person without delving into CLIs.
