### PR TITLE
Remove the fork option in the doc

### DIFF
--- a/plugins/downstream/content.yaml
+++ b/plugins/downstream/content.yaml
@@ -43,12 +43,6 @@ properties:
     description: trigger builds for the repository list, you can mention branch using @.
     secret: false
     required: true
-  fork:
-    type: boolean
-    defaultValue: false
-    description: trigger new build numbers if true, else rebuild.
-    secret: false
-    required: false
   wait:
     type: boolean
     defaultValue: false


### PR DESCRIPTION
The fork has been removed from the implementation already. https://github.com/drone-plugins/drone-downstream/commit/acfef233307b3dace22ceffb0ee139ee68a75752