### PR TITLE
plugin: jfrog artifactory

### DIFF
--- a/plugins/jfrog-artifactory/content.yaml
+++ b/plugins/jfrog-artifactory/content.yaml
@@ -61,14 +61,14 @@ properties:
     secret: false
     required: true
   retries:
-    type: int
+    type: number
     defaultValue: 3
     description: number of upload retries
     secret: false
     required: false
   flat:
-    type: string
-    defaultValue: "false"
+    type: boolean
+    defaultValue: false
     description: if true, artifacts are downloaded to the exact target path specified and their hierarchy in the source repository is ignored. if false, artifacts are downloaded to the target path in the file system while maintaining their hierarchy in the source repository
     secret: false
     required: false

--- a/plugins/jfrog-artifactory/content.yaml
+++ b/plugins/jfrog-artifactory/content.yaml
@@ -6,7 +6,7 @@ tags:
 logo: artifactory.svg
 repo: https://github.com/harness/drone-artifactory
 image: https://hub.docker.com/r/plugins/artifactory
-license: None
+license: Blue Oak Model License 1.0.0
 readme: https://github.com/harness/drone-artifactory/blob/main/README.md
 description: |
   A plugin to upload files to Jfrog artifactory.

--- a/plugins/jfrog-artifactory/content.yaml
+++ b/plugins/jfrog-artifactory/content.yaml
@@ -1,0 +1,74 @@
+title: JFrog Artifactory
+author: harness
+tags:
+  - publish
+  - artifactory
+logo: artifactory.svg
+repo: https://github.com/harness/drone-artifactory
+image: https://hub.docker.com/r/plugins/artifactory
+license: None
+readme: https://github.com/harness/drone-artifactory/blob/main/README.md
+description: |
+  A plugin to upload files to Jfrog artifactory.
+example: |
+  kind: pipeline
+  name: default
+
+  steps:
+  - name: docker  
+    image: plugins/artifactory
+    settings:
+      username: kevinbacon
+      password: pa55word
+      url: company.com/artifactory
+      source: release.tar.gz
+      target: app/release.tar.gz
+properties:
+  username:
+    type: string
+    defaultValue: ""
+    description: username for authentication with artifactory
+    secret: false
+    required: false
+  password:
+    type: string
+    defaultValue: ""
+    description: password for authentication with artifactory
+    secret: true
+    required: false
+  apikey:
+    type: string
+    defaultValue: ""
+    description: key for authentication with artifactory
+    secret: true
+    required: false
+  url:
+    type: string
+    defaultValue: ""
+    description: location of the artifactory server
+    secret: false
+    required: true
+  source:
+    type: string
+    defaultValue: ""
+    description: file(s) to upload
+    secret: false
+    required: true
+  target:
+    type: string
+    defaultValue: ""
+    description: destination of source files in artifactory
+    secret: false
+    required: true
+  retries:
+    type: int
+    defaultValue: 3
+    description: number of upload retries
+    secret: false
+    required: false
+  flat:
+    type: string
+    defaultValue: "false"
+    description: if true, artifacts are downloaded to the exact target path specified and their hierarchy in the source repository is ignored. if false, artifacts are downloaded to the target path in the file system while maintaining their hierarchy in the source repository
+    secret: false
+    required: false


### PR DESCRIPTION
artifactory plugin maintained by harness.

customer support directed a customer to use this plugin, but they were unable to find documentation for it.

Adding it here with the docs so users can see all the options without looking at the code.

There is a current `artifactory` plugin so I prefixed this with `jfrog`, let me know if you have other ideas for conflicting plugins. 