### PR TITLE
fix explanation dry-run for docker plugin

### DIFF
--- a/plugins/docker/content.yaml
+++ b/plugins/docker/content.yaml
@@ -73,7 +73,7 @@ properties:
   dry_run:
     type: string
     defaultValue: ""
-    description: boolean if the docker image should be pushed at the end
+    description: boolean if the docker image should not be pushed at the end
     secret: false
     required: false
   purge:


### PR DESCRIPTION
When dry-run is true, the image will *not* be posted. The description made it sound like the opposite would happen.