### PR TITLE
Qodana jvm community drone plugin

### DIFF
--- a/plugins/qodana-jvm-community-plugin/content.yaml
+++ b/plugins/qodana-jvm-community-plugin/content.yaml
@@ -1,4 +1,4 @@
-title: Qodana JVM Community Drone Plugin
+title: Qodana JVM Community
 author: 2martens
 tags:
   - Qodana

--- a/plugins/qodana-jvm-community-plugin/content.yaml
+++ b/plugins/qodana-jvm-community-plugin/content.yaml
@@ -1,0 +1,37 @@
+title: Qodana JVM Community Drone Plugin
+author: 2martens
+tags:
+  - Qodana
+  - Analysis
+  - report
+repo: https://github.com/2martens/qodana-jvm-community-drone-plugin
+image: https://hub.docker.com/r/2martens/qodana-jvm-community-drone-plugin
+license: Apache License 2.0
+readme: https://github.com/2martens/qodana-jvm-community-drone-plugin/blob/master/README.md
+description: >-
+  This plugin allows you to run the Qodana JVM Community linter in Drone and publish the results
+  to Qodana Cloud. The Community license is enough.
+example: |
+  kind: pipeline
+  name: default
+
+  steps:
+  - name: code-analysis
+    image: 2martens/qodana-jvm-community-drone-plugin
+    settings:
+      qodana_token: yourSecretTokenFromQodanaCloud
+      args: yourArgumentsToQodanaCommand
+properties:
+  qodana_token:
+    type: string
+    defaultValue: ''
+    description: Qodana token used to publish analysis results to Qodana cloud.
+    secret: true
+    required: true
+  args:
+    type: string
+    defaultValue: ''
+    description: Arguments passed to Qodana command. For example --baseline or --failure-threshold
+    secret: false
+    required: true
+

--- a/plugins/qodana-jvm-community-plugin/original.md
+++ b/plugins/qodana-jvm-community-plugin/original.md
@@ -1,0 +1,71 @@
+---
+version: 2023.2
+date: 2023-08-03T00:00:00+00:00
+title: Qodana JVM Community Drone plugin
+author: 2martens
+tags: [ Qodana, Analysis, report ]
+repo: 2martens/qodana-jvm-community-drone-plugin
+image: plugins/pypi
+---
+
+This plugin allows you to run the Qodana JVM Community linter in Drone and publish the results
+to Qodana Cloud. The Community license is enough.
+
+Basic example:
+
+```yaml
+steps:
+- name: code-analysis
+  image: 2martens/qodana-jvm-community-drone-plugin
+  settings:
+    qodana_token: yourSecretTokenFromQodanaCloud
+    args: 
+```
+
+You can also specify a baseline that should be taken into account:
+
+```diff
+steps:
+- name: code-analysis
+  image: 2martens/qodana-jvm-community-drone-plugin
+  settings:
+    qodana_token: yourSecretTokenFromQodanaCloud
+-   args: 
++   args: --baseline qodana.sarif.json
+```
+
+You can also specify a failure threshold that should be taken into account:
+
+```diff
+steps:
+- name: code-analysis
+  image: 2martens/qodana-jvm-community-drone-plugin
+  settings:
+    qodana_token: yourSecretTokenFromQodanaCloud
+-   args: 
++   args: --failure-threshold anyPositiveNumberOrZero
+```
+
+The plugin supports any arguments that Qodana supports. For a full list of options, refer to the
+official documentation: https://www.jetbrains.com/help/qodana/docker-image-configuration.html
+
+Example configuration using token from secrets:
+
+```diff
+steps:
+- name: code-analysis
+  image: 2martens/qodana-jvm-community-drone-plugin
+  settings:
+-   qodana_token: yourSecretTokenFromQodanaCloud
++   qodana_token:
++     from_secret: qodana_token 
+    args:
+```
+
+# Parameter Reference
+
+qodana_token
+: Qodana token used to publish analysis results to Qodana cloud.
+
+args
+: Arguments passed to Qodana command. For example --baseline or --failure-threshold

--- a/plugins/qodana-jvm-community-plugin/original.md
+++ b/plugins/qodana-jvm-community-plugin/original.md
@@ -26,24 +26,24 @@ You can also specify a baseline that should be taken into account:
 
 ```diff
 steps:
-- name: code-analysis
-  image: 2martens/qodana-jvm-community-drone-plugin
-  settings:
-    qodana_token: yourSecretTokenFromQodanaCloud
--   args: 
-+   args: --baseline qodana.sarif.json
+  - name: code-analysis
+    image: 2martens/qodana-jvm-community-drone-plugin
+    settings:
+      qodana_token: yourSecretTokenFromQodanaCloud
+-     args: 
++     args: --baseline qodana.sarif.json
 ```
 
 You can also specify a failure threshold that should be taken into account:
 
 ```diff
-steps:
-- name: code-analysis
-  image: 2martens/qodana-jvm-community-drone-plugin
-  settings:
-    qodana_token: yourSecretTokenFromQodanaCloud
--   args: 
-+   args: --failure-threshold anyPositiveNumberOrZero
+  steps:
+  - name: code-analysis
+    image: 2martens/qodana-jvm-community-drone-plugin
+    settings:
+      qodana_token: yourSecretTokenFromQodanaCloud
+-     args: 
++     args: --failure-threshold anyPositiveNumberOrZero
 ```
 
 The plugin supports any arguments that Qodana supports. For a full list of options, refer to the
@@ -52,14 +52,14 @@ official documentation: https://www.jetbrains.com/help/qodana/docker-image-confi
 Example configuration using token from secrets:
 
 ```diff
-steps:
-- name: code-analysis
-  image: 2martens/qodana-jvm-community-drone-plugin
-  settings:
--   qodana_token: yourSecretTokenFromQodanaCloud
-+   qodana_token:
-+     from_secret: qodana_token 
-    args:
+  steps:
+  - name: code-analysis
+    image: 2martens/qodana-jvm-community-drone-plugin
+    settings:
+-     qodana_token: yourSecretTokenFromQodanaCloud
++     qodana_token:
++       from_secret: qodana_token 
+      args:
 ```
 
 # Parameter Reference


### PR DESCRIPTION
This plugin enables the usage of the Qodana JVM Community linter on Drone. It can be used with a Community (free) license of Qodana.

https://github.com/2martens/qodana-jvm-community-drone-plugin